### PR TITLE
Add "Challenge Created" category for authored challenges

### DIFF
--- a/_posts/2026-04-16-liga-ctf-2026-the-ghost-in-the-git.md
+++ b/_posts/2026-04-16-liga-ctf-2026-the-ghost-in-the-git.md
@@ -1,7 +1,7 @@
 ---
 title:  "OWASP Liga CTF 2026 - The Ghost in the Git"
 date:   2026-04-16 12:00:00 +0800
-categories: [CTF Writeup, OSINT]
+categories: [Challenge Created, OSINT]
 tags: [OWASP Liga CTF 2026]
 ---
 

--- a/_posts/2026-06-23-hacknyx-ctf-2026-deskmesh.md
+++ b/_posts/2026-06-23-hacknyx-ctf-2026-deskmesh.md
@@ -1,7 +1,7 @@
 ---
 title:  "HACKNYX CTF 2026 - Deskmesh Support (Web)"
 date:   2026-06-23 12:00:00 +0800
-categories: [CTF Writeup, Web Exploitation]
+categories: [Challenge Created, Web Exploitation]
 tags: [HACKNYX CTF 2026]
 mermaid: true
 ---

--- a/_posts/2026-06-23-hacknyx-ctf-2026-middle-management.md
+++ b/_posts/2026-06-23-hacknyx-ctf-2026-middle-management.md
@@ -1,7 +1,7 @@
 ---
 title:  "HACKNYX CTF 2026 - Middle Management (Web)"
 date:   2026-06-23 14:00:00 +0800
-categories: [CTF Writeup, Web Exploitation]
+categories: [Challenge Created, Web Exploitation]
 tags: [HACKNYX CTF 2026]
 mermaid: true
 ---

--- a/_posts/2026-06-23-hacknyx-ctf-2026-no-slang.md
+++ b/_posts/2026-06-23-hacknyx-ctf-2026-no-slang.md
@@ -1,7 +1,7 @@
 ---
 title:  "HACKNYX CTF 2026 - No Slang Series (Web)"
 date:   2026-06-23 13:00:00 +0800
-categories: [CTF Writeup, Web Exploitation]
+categories: [Challenge Created, Web Exploitation]
 tags: [HACKNYX CTF 2026]
 mermaid: true
 ---

--- a/assets/feed.xml
+++ b/assets/feed.xml
@@ -1,0 +1,56 @@
+---
+layout: compress
+permalink: /feed.xml
+# Atom Feed, reference: https://validator.w3.org/feed/docs/atom.html
+# Local override of the Chirpy theme template: raises the entry limit from 5 to 20
+# so downstream consumers (e.g. the portfolio site) have enough posts to filter.
+---
+
+{% capture source %}
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>{{ "/" | absolute_url }}</id>
+  <title>{{ site.title }}</title>
+  <subtitle>{{ site.description }}</subtitle>
+  <updated>{{ site.time | date_to_xmlschema }}</updated>
+  <author>
+    <name>{{ site.social.name }}</name>
+    <uri>{{ "/" | absolute_url }}</uri>
+  </author>
+  <link rel="self" type="application/atom+xml" href="{{ page.url | absolute_url }}"/>
+  <link rel="alternate" type="text/html" hreflang="{{ site.alt_lang | default: site.lang }}"
+    href="{{ '/' | absolute_url }}"/>
+  <generator uri="https://jekyllrb.com/" version="{{ jekyll.version }}">Jekyll</generator>
+  <rights> © {{ 'now' | date: '%Y' }} {{ site.social.name }} </rights>
+  <icon>{{ site.baseurl }}/assets/img/favicons/favicon.ico</icon>
+  <logo>{{ site.baseurl }}/assets/img/favicons/favicon-96x96.png</logo>
+
+{% for post in site.posts limit: 20 %}
+  {% assign post_absolute_url = post.url | absolute_url %}
+  <entry>
+    <title>{{ post.title }}</title>
+    <link href="{{ post_absolute_url }}" rel="alternate" type="text/html" title="{{ post.title | xml_escape }}" />
+    <published>{{ post.date | date_to_xmlschema }}</published>
+  {% if post.last_modified_at %}
+    <updated>{{ post.last_modified_at | date_to_xmlschema }}</updated>
+  {% else %}
+    <updated>{{ post.date | date_to_xmlschema }}</updated>
+  {% endif %}
+    <id>{{ post_absolute_url }}</id>
+    <content type="text/html" src="{{ post_absolute_url }}" />
+    <author>
+      <name>{{ post.author | default: site.social.name }}</name>
+    </author>
+
+  {% if post.categories %}
+    {% for category in post.categories %}
+    <category term="{{ category }}" />
+    {% endfor %}
+  {% endif %}
+
+  <summary>{% include post-summary.html max_length=400 %}</summary>
+
+  </entry>
+{% endfor %}
+</feed>
+{% endcapture %}
+{{ source | replace: '&', '&amp;' }}


### PR DESCRIPTION
## What

The 4 posts that document challenges **I built** for public CTFs — OWASP Liga CTF 2026, and HACKNYX CTF 2026 (Middle Management, No Slang, Deskmesh) — move from `CTF Writeup` to a new **`Challenge Created`** first category. Solve writeups keep `CTF Writeup`. `HTB Meetup IIUM` stays `Meetup Writeup`.

This creates `/categories/challenge-created/` and tags those posts' `<category>` term in the Atom feed, so consumers can tell authored challenges apart from solve writeups.

## Feed limit

`assets/feed.xml` is added as a local override of the Chirpy theme template, raising the entry cap from **5 → 20**. The portfolio site (`Jerit3787.github.io`) consumes `/feed.xml` for its "Writeups" row and needs enough entries to filter authored challenges out.

Template copied verbatim from `jekyll-theme-chirpy@7.6.0`, only `limit: 5` → `limit: 20`.