### PR TITLE
Fix: UTAR posts were future-dated, breaking the build

### DIFF
--- a/_posts/2026-09-09-utar-cyberhunt-2026-publicnotes.md
+++ b/_posts/2026-09-09-utar-cyberhunt-2026-publicnotes.md
@@ -1,6 +1,6 @@
 ---
 title:  "UTAR CyberHunt 2026 - PublicNotes (Web)"
-date:   2026-09-09 20:00:00 +0800
+date:   2026-09-09 09:00:00 +0800
 categories: [Challenge Created, Web Exploitation]
 tags: [UTAR CyberHunt 2026]
 media_subpath: /assets/img/utar-cyberhunt-2026/

--- a/_posts/2026-09-09-utar-cyberhunt-2026-threadjack.md
+++ b/_posts/2026-09-09-utar-cyberhunt-2026-threadjack.md
@@ -1,6 +1,6 @@
 ---
 title:  "UTAR CyberHunt 2026 - ThreadJack (Web)"
-date:   2026-09-09 21:00:00 +0800
+date:   2026-09-09 10:00:00 +0800
 categories: [Challenge Created, Web Exploitation]
 tags: [UTAR CyberHunt 2026]
 media_subpath: /assets/img/utar-cyberhunt-2026/


### PR DESCRIPTION
The `21:00 +08:00` timestamp on the ThreadJack post = 13:00 UTC, which was ahead of the Pages CI run — Jekyll's `future: false` skipped it, so htmlproofer failed on PublicNotes' cross-link to it. Both post times moved to 09:00 / 10:00 +08:00 (early UTC). No content change.