### PR TITLE
Fix: jinja payloads eaten by Liquid in no-slang / deskmesh

### DIFF
--- a/_posts/2026-06-23-hacknyx-ctf-2026-deskmesh.md
+++ b/_posts/2026-06-23-hacknyx-ctf-2026-deskmesh.md
@@ -163,10 +163,12 @@ So after `/escalate`, the bot carries an `auth` cookie whose payload contains Fl
 
 It reflects the `banner` cookie unescaped (`templates/status.html`):
 
+{% raw %}
 ```jinja
 <p>{{ banner | safe }}</p>
 ```
 {: file="templates/status.html" }
+{% endraw %}
 
 **The sandwich** abuses Werkzeug's **quoted-string cookie parsing**. A cookie value that begins with a double quote `"` is parsed as a quoted string, and parsing continues — swallowing `;` separators and any cookies in between — **until the closing `"`**. So if we can place our `banner` cookie *before* the `httponly` `auth` cookie and leave the quote open, then place a closing quote *after* it, the `auth` cookie's bytes get **absorbed into our reflected `banner` value**. That's the "sandwich": our bread on both sides, the secret cookie in the middle.
 

--- a/_posts/2026-06-23-hacknyx-ctf-2026-no-slang.md
+++ b/_posts/2026-06-23-hacknyx-ctf-2026-no-slang.md
@@ -104,9 +104,11 @@ That's the skeleton. Every flag below is "make this exact chain survive one more
 
 The Easy level has nothing but the quote filter, so the shared chain works as-is. Since quotes are banned inside `keycode` too, we encode the SSTI string with MySQL's `CHAR()` so no literal quotes ever appear:
 
+{% raw %}
 ```jinja2
 {{lipsum.__globals__.os.popen('/readflag').read()}}
 ```
+{% endraw %}
 
 Final inputs:
 
@@ -150,7 +152,7 @@ SUBSTRING_INDEX(SUBSTRING_INDEX(INFO, CHAR(...'operator = (\''...), -1), CHAR(..
 
 The key move: we put the payload into the **operator field** this time, with a trailing `\` to escape the literal, and make the SSTI read its command from a request arg so it stays quote-free:
 
-- **operator**: `{{lipsum.__globals__.os.popen(request.args.rce).read()}}\`
+- **operator**: {% raw %}`{{lipsum.__globals__.os.popen(request.args.rce).read()}}\`{% endraw %}
 - **keycode**:
   ```sql
   ) UNION SELECT <extract operator>, <extract keycode>


### PR DESCRIPTION
The `{{lipsum.__globals__.os.popen('/readflag').read()}}` block in **no-slang** renders empty on the live site — Jekyll evaluates Liquid over the raw markdown before kramdown, and `{{ ... }}` with an undefined variable becomes an empty string.

Wrapped the three affected spots (no-slang: the SSTI code block + the inline Flag-2 operator payload; deskmesh: `{{ banner | safe }}`) in `{% raw %}`/`{% endraw %}`, same as the existing convention in htb-spookify / igoh.

Validated locally with `docker run ruby:3.3-slim … bundle exec jekyll build` — `{{lipsum…}}` now appears in `_site/…/index.html` and no `{% raw %}` tags leak.